### PR TITLE
Change skip clause for release to main branch

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -110,7 +110,7 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     steps:
     - name: Download a single artifact
       uses: actions/download-artifact@v3


### PR DESCRIPTION
The current implementation was checking for the master branch, but actualle a main branch is used