### PR TITLE
added missing package parm name in readme jinja template

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 *****
 
 [![HitCount](https://hits.dwyl.com/BMeyn/temp_python_pkg.svg?style=flat-square)](http://hits.dwyl.com/BMeyn/temp_python_pkg)
-[![PyPI version](https://badge.fury.io/py/BMeyn.svg)](https://badge.fury.io/py)
+[![PyPI version](https://badge.fury.io/py/BMeyn.svg)](https://badge.fury.io/py/BMeyn)
 [![Tests Status](https://BMeyn.github.io/temp_python_pkg/docs/badget/unittest-badget.svg?dummy=8484744)]()
 [![Coverage Status](https://BMeyn.github.io/temp_python_pkg/docs/badget/coverage-badget.svg?dummy=8484744)]()
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,19 +1,25 @@
 # Release Notes 
 ## Run Details
 - Workflow: Python package CI/CD 
-- Head Branch: bugfix/missing_import 
-- Head SHA: 3c77bf52643b1c211d789e2c65fa2e6090f16cad 
+- Head Branch: bugfix/missing_readme_parm 
+- Head SHA: a4701ea25a792f1cd41c4f7b372b910f94d27a7f 
 
 ## Pull Requests
-**45** added missing os import in setup.py
+**46** added missing package parm name in readme jinja template
 ### Commits
-  - **3c77bf52643b1c211d789e2c65fa2e6090f16cad** added missing os import in setup.py
+  - **a4701ea25a792f1cd41c4f7b372b910f94d27a7f** added missing package parm name in readme jinja template
 ### Comments
  - ## Unit Test Results
 1 files  ±0  1 suites  ±0   0s [:stopwatch:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;duration of all tests&quot;) ±0s
 1 tests ±0  1 [:heavy_check_mark:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;passed tests&quot;) ±0  0 [:zzz:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;skipped / disabled tests&quot;) ±0  0 [:x:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;failed tests&quot;) ±0 
 
-Results for commit 3c77bf52. ± Comparison against base commit c4054cb6.
+Results for commit a4701ea2. ± Comparison against base commit cf9b0bbc.
+
+ - ## Unit Test Results
+1 files  ±0  1 suites  ±0   0s [:stopwatch:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;duration of all tests&quot;) ±0s
+1 tests ±0  1 [:heavy_check_mark:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;passed tests&quot;) ±0  0 [:zzz:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;skipped / disabled tests&quot;) ±0  0 [:x:](https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.20/README.md#the-symbols &quot;failed tests&quot;) ±0 
+
+Results for commit a4701ea2. ± Comparison against base commit cf9b0bbc.
 
 :recycle: This comment has been updated with latest results.
 

--- a/templates/readme_jinja/readme_template.j2
+++ b/templates/readme_jinja/readme_template.j2
@@ -5,7 +5,7 @@
 *****
 
 [![HitCount](https://hits.dwyl.com/{{github_owner}}/{{github_repo}}.svg?style=flat-square)](http://hits.dwyl.com/{{github_owner}}/{{github_repo}})
-[![PyPI version](https://badge.fury.io/py/{{package_name}}.svg)](https://badge.fury.io/py)
+[![PyPI version](https://badge.fury.io/py/{{package_name}}.svg)](https://badge.fury.io/py/{{package_name}})
 [![Tests Status](https://{{github_owner}}.github.io/{{github_repo}}/docs/badget/unittest-badget.svg?dummy=8484744)]()
 [![Coverage Status](https://{{github_owner}}.github.io/{{github_repo}}/docs/badget/coverage-badget.svg?dummy=8484744)]()
 


### PR DESCRIPTION
The pipy version badget excpect also the version name in the path.
This was missing before